### PR TITLE
Add BSD 3-Clause LICENSE, copyright headers, and enhanced CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,88 @@
-# Contributing to Wall-x
+# Contributing to Wall-X
 
-## Submit a Pull Request
+Thank you for your interest in contributing to Wall-X! This document provides guidelines to help you get started.
 
-Before opening a pull request, please make sure your code passes the lint checks.
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [How to Contribute](#how-to-contribute)
+  - [Reporting Issues](#reporting-issues)
+  - [Suggesting Features](#suggesting-features)
+  - [Pull Requests](#pull-requests)
+- [Development Setup](#development-setup)
+- [Coding Guidelines](#coding-guidelines)
+- [License](#license)
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. We aim to foster an inclusive and welcoming community.
+
+## How to Contribute
+
+### Reporting Issues
+
+If you find a bug or have a problem using Wall-X, please open an issue on GitHub:
+
+1. Search [existing issues](https://github.com/X-Square-Robot/wall-x/issues) to avoid duplicates
+2. Use a clear, descriptive title
+3. Include steps to reproduce the issue
+4. Provide your environment details (OS, Python version, CUDA version, PyTorch version)
+5. Attach relevant logs or error messages
+
+### Suggesting Features
+
+Feature suggestions are welcome! Open an issue with:
+
+- A clear description of the feature
+- Motivation (what problem does it solve?)
+- Any alternative solutions you've considered
+
+### Pull Requests
+
+Before opening a pull request, please:
+
+1. **Fork the repository** and create a new branch from `main`
+2. **Make your changes** following the [coding guidelines](#coding-guidelines)
+3. **Test your changes** thoroughly
+4. **Ensure lint checks pass:**
 
 ```bash
 # Install pre-commit hooks (run once)
 pre-commit install
 ```
 
-Or
+Or run manually:
 
 ```bash
 # Manually run all checks
 pre-commit run --all-files
 ```
+
+5. **Submit a pull request** with a clear description of your changes
+
+## Development Setup
+
+See the [README](README.md#environment-setup) for full environment setup instructions.
+
+In short:
+
+```bash
+conda create --name wallx python=3.10
+conda activate wallx
+pip install -r requirements.txt
+MAX_JOBS=4 pip install flash-attn==2.7.4.post1 --no-build-isolation
+git submodule update --init --recursive
+MAX_JOBS=4 pip install --no-build-isolation --verbose -e .
+```
+
+## Coding Guidelines
+
+- Follow [PEP 8](https://peps.python.org/pep-0008/) for Python code style
+- Use type hints where practical
+- Write docstrings for public functions and classes
+- Keep changes focused — one feature or fix per PR
+- Add or update tests when applicable
+
+## License
+
+By contributing to Wall-X, you agree that your contributions will be licensed under the [BSD 3-Clause License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, X-Square-Robot
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUD, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/scripts/compute_norm_stats.py
+++ b/scripts/compute_norm_stats.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
 
 import json
 import logging

--- a/scripts/draw_openloop_plot.py
+++ b/scripts/draw_openloop_plot.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import yaml
 import torch

--- a/scripts/fake_inference.py
+++ b/scripts/fake_inference.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import torch
 from wall_x.model.qwen2_5_based.modeling_qwen2_5_vl_act import Qwen2_5_VLMoEForAction
 

--- a/scripts/infer_libero.py
+++ b/scripts/infer_libero.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import argparse
 import time
 import os

--- a/scripts/infer_robochallenge.py
+++ b/scripts/infer_robochallenge.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 from scipy.fft import dct
 from scipy.fft import idct

--- a/scripts/merge_sharded_weights.py
+++ b/scripts/merge_sharded_weights.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 Custom script to merge FSDP sharded checkpoints with compatibility handling.
 Works around the StorageMeta compatibility issue between PyTorch versions.

--- a/scripts/merge_tokenizer.py
+++ b/scripts/merge_tokenizer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 from transformers import AutoProcessor
 import os
 

--- a/scripts/normalize.py
+++ b/scripts/normalize.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 # This file is copied from openpi
 import json
 import pathlib

--- a/scripts/vqa_inference.py
+++ b/scripts/vqa_inference.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import torch
 from PIL import Image
 from transformers import AutoProcessor

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import torch
 from pathlib import Path

--- a/train_qact.py
+++ b/train_qact.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import json
 import time

--- a/wall_x/__init__.py
+++ b/wall_x/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/wall_x/data/__init__.py
+++ b/wall_x/data/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/wall_x/data/config.py
+++ b/wall_x/data/config.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 from typing import List, Dict, Optional
 from dataclasses import dataclass, field
 from qwen_vl_utils.vision_process import MIN_PIXELS, MAX_PIXELS, IMAGE_FACTOR

--- a/wall_x/data/load_lerobot_dataset.py
+++ b/wall_x/data/load_lerobot_dataset.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 LeRobot Dataset Loader - Distributed Version
 """

--- a/wall_x/data/utils.py
+++ b/wall_x/data/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 Data processing utilities for Wall-X multimodal robotic learning.
 

--- a/wall_x/fusions/__init__.py
+++ b/wall_x/fusions/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/wall_x/fusions/backend.py
+++ b/wall_x/fusions/backend.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 High-performance C++ backend interface for optimized matrix operations.
 

--- a/wall_x/fusions/ops.py
+++ b/wall_x/fusions/ops.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import torch
 import warnings
 from wall_x.fusions import backend

--- a/wall_x/infer/base_dataclass.py
+++ b/wall_x/infer/base_dataclass.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 from wall_x.infer.infer_config import InferConfig
 from typing import Optional, List
 from dataclasses import dataclass, field

--- a/wall_x/infer/env.py
+++ b/wall_x/infer/env.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 Base Environment Class for Robot Control and Inference
 """

--- a/wall_x/infer/env_libero.py
+++ b/wall_x/infer/env_libero.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import json
 import numpy as np

--- a/wall_x/infer/infer_config.py
+++ b/wall_x/infer/infer_config.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import yaml
 import os
 from wall_x.model.model_utils import update_model_config

--- a/wall_x/infer/logger.py
+++ b/wall_x/infer/logger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 Hierarchical Inference Logging System
 

--- a/wall_x/infer/utils.py
+++ b/wall_x/infer/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import numpy as np
 from scipy.signal import savgol_filter
 from scipy.spatial.transform import Rotation as R  # TODO: Convert to numba functions

--- a/wall_x/infer/utils_libero.py
+++ b/wall_x/infer/utils_libero.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """Utils for evaluating policies in LIBERO simulation environments."""
 
 import math

--- a/wall_x/model/__init__.py
+++ b/wall_x/model/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/wall_x/model/action_head.py
+++ b/wall_x/model/action_head.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import torch
 
 import torch.nn as nn

--- a/wall_x/model/joint_attention.py
+++ b/wall_x/model/joint_attention.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import torch
 import torch.nn as nn
 from typing import Optional, Tuple

--- a/wall_x/model/model_utils.py
+++ b/wall_x/model/model_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import torch
 import os
 import numpy as np

--- a/wall_x/model/qwen2_5_based/__init__.py
+++ b/wall_x/model/qwen2_5_based/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 from .modeling_qwen2_5_vl_act import Qwen2_5_VLMoEModel, Qwen2_5_VLMoEForAction
 from .configuration_qwen2_5_vl import Qwen2_5_VLConfig
 

--- a/wall_x/model/qwen2_5_based/configuration_qwen2_5_vl.py
+++ b/wall_x/model/qwen2_5_based/configuration_qwen2_5_vl.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_rope_utils import rope_config_validation
 

--- a/wall_x/model/qwen2_5_based/modeling_qwen2_5_vl.py
+++ b/wall_x/model/qwen2_5_based/modeling_qwen2_5_vl.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import math
 import torch
 import torch.nn as nn

--- a/wall_x/model/qwen2_5_based/modeling_qwen2_5_vl_act.py
+++ b/wall_x/model/qwen2_5_based/modeling_qwen2_5_vl_act.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import torch
 import yaml

--- a/wall_x/model/vla_mixin.py
+++ b/wall_x/model/vla_mixin.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp

--- a/wall_x/serving/__init__.py
+++ b/wall_x/serving/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 from .websocket_policy_server import WebsocketPolicyServer, BasePolicy
 
 __all__ = ["WebsocketPolicyServer", "BasePolicy"]

--- a/wall_x/serving/client.py
+++ b/wall_x/serving/client.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 Example client for Wall-X model server with sync support.
 

--- a/wall_x/serving/launch_serving.py
+++ b/wall_x/serving/launch_serving.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 """
 Server script for Wall-X model.
 

--- a/wall_x/serving/policy/__init__.py
+++ b/wall_x/serving/policy/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 from .wall_x_policy import WallXPolicy
 
 __all__ = ["WallXPolicy"]

--- a/wall_x/serving/policy/utils.py
+++ b/wall_x/serving/policy/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 from typing import Dict, List
 import logging
 import numpy as np

--- a/wall_x/serving/policy/wall_x_policy.py
+++ b/wall_x/serving/policy/wall_x_policy.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
 from typing import Dict, Any, List
 import torch

--- a/wall_x/serving/websocket_policy_server.py
+++ b/wall_x/serving/websocket_policy_server.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import asyncio
 import http
 import logging

--- a/wall_x/trainer/__init__.py
+++ b/wall_x/trainer/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/wall_x/trainer/qwen_vl_act_trainer.py
+++ b/wall_x/trainer/qwen_vl_act_trainer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import gc
 import time

--- a/wall_x/utils/__init__.py
+++ b/wall_x/utils/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/wall_x/utils/constant.py
+++ b/wall_x/utils/constant.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 action_statistic_dof = {
     "x2_normal": {
         # water flowers

--- a/wall_x/utils/timers.py
+++ b/wall_x/utils/timers.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, X-Square-Robot
+# SPDX-License-Identifier: BSD-3-Clause
+
 import time
 from torch.cuda import nvtx
 from abc import ABC, abstractmethod


### PR DESCRIPTION
## Summary

Fixes #91 — Adds missing license details, copyright notices, and contribution guidelines.

### Changes

1. **LICENSE** — Added full BSD 3-Clause License text (matching the `License :: OSI Approved :: BSD License` classifier already declared in `setup.py`)

2. **Copyright Headers** — Added copyright notice with SPDX license identifier to all 47 Python source files:
   ```python
   # Copyright (c) 2025, X-Square-Robot
   # SPDX-License-Identifier: BSD-3-Clause
   ```

3. **CONTRIBUTING.md** — Expanded with:
   - Issue reporting guidelines
   - Feature suggestion process
   - Pull request workflow
   - Development setup instructions
   - Coding guidelines (PEP 8, type hints, docstrings)
   - License terms for contributors