### PR TITLE
Fix lerobot fine-tuning out of the box: version-robust checkpoint loading, optional flash-attn, episode passthrough

### DIFF
--- a/wall_x/data/load_lerobot_dataset.py
+++ b/wall_x/data/load_lerobot_dataset.py
@@ -498,9 +498,16 @@ def load_lerobot_data(
     batch_size = config.get("batch_size_per_gpu", 8)
     episodes = np.arange(episodes_num).tolist()
 
-    train_test_split = dataload_config.get("train_test_split", 0.95)
-    train_episodes = episodes[: int(episodes_num * train_test_split)]
-    test_episodes = episodes[int(episodes_num * train_test_split) :]
+    # Respect an explicit episode list from lerobot_config (e.g. to hold out
+    # evaluation episodes); falls back to the original sequential split
+    cfg_episodes = lerobot_config.get("episodes", None)
+    if cfg_episodes:
+        train_episodes = list(cfg_episodes)
+        test_episodes = [e for e in episodes if e not in set(train_episodes)]
+    else:
+        train_test_split = dataload_config.get("train_test_split", 0.95)
+        train_episodes = episodes[: int(episodes_num * train_test_split)]
+        test_episodes = episodes[int(episodes_num * train_test_split) :]
 
     train_dataset = LeRobotDataset(
         repo_id,

--- a/wall_x/model/joint_attention.py
+++ b/wall_x/model/joint_attention.py
@@ -9,10 +9,20 @@ from wall_x.fusions import ops
 from wall_x.model.qwen2_5_based.modeling_qwen2_5_vl import (
     apply_multimodal_rotary_pos_emb,
 )
-from flash_attn import flash_attn_func
-from transformers.modeling_flash_attention_utils import (
-    is_flash_attn_greater_or_equal_2_10,
-)
+# flash-attn is an optional dependency: only the flash_attention_2 attention
+# class needs it; sdpa/eager paths never call flash_attn_func
+try:
+    from flash_attn import flash_attn_func
+except ImportError:
+    flash_attn_func = None
+try:
+    from transformers.modeling_flash_attention_utils import (
+        is_flash_attn_greater_or_equal_2_10,
+    )
+except ImportError:
+
+    def is_flash_attn_greater_or_equal_2_10():
+        return True
 from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
     Qwen2_5_VLRotaryEmbedding,
     repeat_kv,

--- a/wall_x/model/qwen2_5_based/modeling_qwen2_5_vl_act.py
+++ b/wall_x/model/qwen2_5_based/modeling_qwen2_5_vl_act.py
@@ -921,7 +921,75 @@ class Qwen2_5_VLMoEForAction(
             state_dict.update(sd)
         if embed_tokens_size != len(processor.tokenizer):
             model.resize_token_embeddings(embed_tokens_size)
-        model.load_state_dict(state_dict, strict=False)
+        # Checkpoints may store fused projections (qkv_proj_experts /
+        # gate_up_proj, newer transformers naming) while the installed
+        # transformers version builds split modules. Slice fused tensors along
+        # dim 0 using the target sibling shapes (HF concat order: q;k;v / gate;up).
+        _model_sd = model.state_dict()
+
+        def _split_fused(fused_key, part_keys):
+            v = state_dict.pop(fused_key)
+            sizes = [_model_sd[p].shape[0] for p in part_keys]
+            if sum(sizes) != v.shape[0]:
+                print(
+                    f"Warning: skip fused split {fused_key}: "
+                    f"{v.shape[0]} != {sizes}",
+                    flush=True,
+                )
+                state_dict[fused_key] = v
+                return 0
+            off = 0
+            for p, s in zip(part_keys, sizes):
+                state_dict[p] = v[off : off + s].clone()
+                off += s
+            return 1
+
+        _n_split = 0
+        for _k in list(state_dict.keys()):
+            _base, _, _kind = _k.rpartition(".")
+            if ".self_attn.qkv_proj_experts." in _k:
+                _parts = [
+                    _base.replace("qkv_proj_experts", f"{x}_proj_experts") + "." + _kind
+                    for x in ("q", "k", "v")
+                ]
+            elif _base.endswith("gate_up_proj"):
+                _parts = [
+                    _base.replace("gate_up_proj", f"{x}_proj") + "." + _kind
+                    for x in ("gate", "up")
+                ]
+            else:
+                continue
+            if all(p in _model_sd for p in _parts):
+                _n_split += _split_fused(_k, _parts)
+        if _n_split:
+            print(
+                f"Adapted {_n_split} fused checkpoint tensors to split module naming",
+                flush=True,
+            )
+
+        # Drop checkpoint tensors whose shape disagrees with the current build
+        # (e.g. multi-embodiment action in/out projections vs a customized
+        # dof_config); those layers re-initialize for the new embodiment.
+        # load_state_dict(strict=False) alone still raises on shape mismatch.
+        for _k in list(state_dict.keys()):
+            if _k in _model_sd and state_dict[_k].shape != _model_sd[_k].shape:
+                print(
+                    f"Re-initializing shape-mismatched checkpoint key {_k}: "
+                    f"{tuple(state_dict[_k].shape)} -> fresh init {tuple(_model_sd[_k].shape)}",
+                    flush=True,
+                )
+                del state_dict[_k]
+        _load_report = model.load_state_dict(state_dict, strict=False)
+        # Report what actually loaded; silent key mismatches are hard to debug
+        print(
+            f"Pretrained weight load report: {len(_load_report.missing_keys)} missing, "
+            f"{len(_load_report.unexpected_keys)} unexpected",
+            flush=True,
+        )
+        for _k in _load_report.missing_keys[:40]:
+            print(f"  missing: {_k}", flush=True)
+        for _k in _load_report.unexpected_keys[:40]:
+            print(f"  unexpected: {_k}", flush=True)
 
         return model
 

--- a/wall_x/trainer/qwen_vl_act_trainer.py
+++ b/wall_x/trainer/qwen_vl_act_trainer.py
@@ -590,6 +590,9 @@ class QwenVlAct_Trainer:
                     if self.use_fast_tokenizer
                     else None
                 ),
+                # propagate selective recompute into the model build
+                # (the config flag was silently ignored on this branch)
+                use_selective_recompute=self.use_selective_recompute,
             )
             self.processor = model.processor
             model = model.to(torch.bfloat16)
@@ -663,7 +666,14 @@ class QwenVlAct_Trainer:
             print("Freezing VLM parameters, training only MoE experts", flush=True)
             moe_params = []
             for name, param in model.named_parameters():
-                if "moe.experts.1." not in name:
+                # Optionally keep action_preprocessor trainable: its action
+                # in/out projections re-initialize when fine-tuning a customized
+                # dof_config and must then train alongside the experts
+                # (enable via train_action_preprocessor: true)
+                _train_ap = self.config.get("train_action_preprocessor", False) and (
+                    "action_preprocessor." in name and "normalizer" not in name
+                )
+                if "moe.experts.1." not in name and not _train_ap:
                     param.requires_grad = False
                 else:
                     moe_params.append(param)

--- a/wall_x/trainer/qwen_vl_act_trainer.py
+++ b/wall_x/trainer/qwen_vl_act_trainer.py
@@ -954,10 +954,13 @@ class QwenVlAct_Trainer:
                 os.path.join(ckpt_path, "normalizer_propri.pth"),
             )
 
-        # Save current iter steps
-        if step != 0:  # step==0, no need for dataset resume
+        # Save current iter steps. Guarded: lerobot datasets have no pool
+        # cursors, and self.data_config does not exist on this class (the
+        # attribute is dataload_config), so every checkpoint save on the
+        # lerobot path raised AttributeError here.
+        if step != 0 and hasattr(self.dataset, "secondary_pool_start_index"):
             _rank = self.accelerator.process_index
-            if self.data_config["multimodal_data_ratio"] != 1:
+            if self.config.get("multimodal_data_ratio", 1) != 1:
                 torch.save(
                     {
                         "episode_start_index": self.dataset.primary_pool_start_index.value


### PR DESCRIPTION
## Summary

Following the workspace README to fine-tune **wall-oss-0.5** on a custom lerobot dataset currently breaks in several environment-dependent ways. This PR makes that path work out of the box:

1. **Version-robust checkpoint loading** (`modeling_qwen2_5_vl_act.py`)
   - The released checkpoint stores **fused** projections (`qkv_proj_experts.*`, `gate_up_proj`). With transformers versions that build **split** modules (e.g. 4.51.x, which is needed anyway since `AttentionInterface` does not exist in the pinned 4.49.0), `load_state_dict(strict=False)` silently skips ~700 tensors: all LM attention/MLP expert weights and every vision-tower MLP stay randomly initialized while training appears to run normally. This PR slices fused tensors into the split naming, with split sizes taken from the model's own state_dict (HF concat order q;k;v / gate;up), so it is a no-op on environments where names already match.
   - Checkpoint tensors whose shapes disagree with a customized `dof_config` (e.g. the 26-dim multi-embodiment action projections vs a custom single-arm config) previously raised `RuntimeError` even with `strict=False`; they now re-initialize with a clear message, which is the expected behavior when adapting to a new embodiment per the workspace README.
   - A load report (missing/unexpected counts + first keys) is printed so silent loading issues are visible.

2. **Optional flash-attn** (`joint_attention.py`): `flash_attn` is imported at module level but is not listed in `requirements.txt`, so a fresh install crashes at import. It is now optional; only the flash_attention_2 attention class needs it, sdpa/eager paths never call it.

3. **Episode list passthrough** (`load_lerobot_dataset.py`): `lerobot_config.episodes` exists in the config template but was ignored; the loader always used a sequential train/test split. Honoring it allows holding out evaluation episodes.

4. **`use_selective_recompute` passthrough** (`qwen_vl_act_trainer.py`): the wall-oss branch dropped this flag when calling `from_pretrained`, silently disabling selective recompute.

5. **Opt-in `train_action_preprocessor`** (`qwen_vl_act_trainer.py`): with `freeze_vlm: true` and a customized `dof_config`, the freshly re-initialized action in/out projections were frozen at random init. The new flag keeps them trainable alongside the experts; default `false` preserves current behavior.

## Validation

Fine-tuned wall-oss-0.5 on a custom 7-DoF single-arm lerobot dataset (3 cameras, joint space + gripper), transformers 4.51.3 / torch 2.10 / python 3.12 / RTX 4090 (sm_89):

- Load report after this PR: **280 fused tensors adapted, 4 missing / 0 unexpected** (tied `lm_head`, `propri_proj` which is absent from the released checkpoint, and the two intentionally re-initialized action projections)
- Single 24GB GPU fine-tune runs healthily with `freeze_vlm` + selective recompute, bf16, bs1

## Note

`requirements.txt` pins `transformers==4.49.0`, but `wall_x/model/vla_mixin.py` imports `AttentionInterface`, which does not exist in 4.49; the pin may want a bump to >=4.50 in a separate change.